### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides AI assistants with Safari browser automation and developer tools access. This server enables LLMs to interact with Safari, access console logs, monitor network activity, and perform browser automation tasks.
 
+<a href="https://glama.ai/mcp/servers/@lxman/safari-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lxman/safari-mcp-server/badge" alt="Safari Server MCP server" />
+</a>
+
 ## Features
 
 - 🚀 **Safari Browser Automation**: Start, control, and manage Safari sessions


### PR DESCRIPTION
This PR adds a badge for the [Safari MCP Server](https://glama.ai/mcp/servers/@lxman/safari-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lxman/safari-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lxman/safari-mcp-server/badge" alt="Safari Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.